### PR TITLE
feat: Restrict place_exacta_bet to operator only

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -762,7 +762,7 @@ function App() {
       addLog(`  Multiplier: x${multiplier}`, 'info');
       addLog(`  Potential Win: ${(betAmountTokens * multiplier).toFixed(2)} tokens`, 'reward');
       
-      await sendTxAndWait('placeExactaBet', [playerBet.first, playerBet.second, betAmountSmallest.toString()]);
+      await sendTxAndWait('placeExactaBet', [selectedAccount.address, playerBet.first, playerBet.second, betAmountSmallest.toString()]);
       addLog('✓ Bet placed successfully!', 'success');
       setPlayerBetPlaced(true);
       
@@ -1038,7 +1038,7 @@ function App() {
     try {
       setLoading(prev => ({ ...prev, placeBet: true }));
       const value = new BN(betAmount || '0');
-      await sendTxAndWait('placeExactaBet', [parseInt(firstPick), parseInt(secondPick), value.toString()]);
+      await sendTxAndWait('placeExactaBet', [selectedAccount.address, parseInt(firstPick), parseInt(secondPick), value.toString()]);
       setResults(prev => ({ ...prev, placeBet: { success: 'Bet placed successfully!' } }));
     } catch (error) {
       setResults(prev => ({ ...prev, placeBet: { error: error.message } }));

--- a/frontend/src/metadata.json
+++ b/frontend/src/metadata.json
@@ -1,6 +1,6 @@
 {
   "source": {
-    "hash": "0xefbb5c3654e4253357808ba876ec8a3269c059dcd7bb8377f48fae4c3964d516",
+    "hash": "0x3fe08f20b0afefae9cb2cff3cf811c297958c7f72ab3d22431e10e0150433bbb",
     "language": "ink! 5.1.1",
     "compiler": "rustc 1.92.0",
     "build_info": {
@@ -452,6 +452,15 @@
       {
         "args": [
           {
+            "label": "bettor",
+            "type": {
+              "displayName": [
+                "AccountId"
+              ],
+              "type": 0
+            }
+          },
+          {
             "label": "first_pick",
             "type": {
               "displayName": [
@@ -482,7 +491,8 @@
         "default": false,
         "docs": [
           " Place an exacta bet (predict 1st and 2nd place in order)",
-          " Deducts the bet amount from the caller's asset balance"
+          " Only the operator (owner) can call this function",
+          " Deducts the bet amount from the bettor's asset balance"
         ],
         "label": "place_exacta_bet",
         "mutates": true,


### PR DESCRIPTION
- Add owner check to place_exacta_bet function
- Add bettor parameter so operator can place bets on behalf of users
- Deduct from bettor's asset balance (not caller's)
- Update frontend to pass bettor address
- Betting still uses u128 assets (not native tokens)

Closes #2