### PR TITLE
feat: Add fee distribution on bet placement (Dev, Operator, Pot)

### DIFF
--- a/frontend/src/metadata.json
+++ b/frontend/src/metadata.json
@@ -1,6 +1,6 @@
 {
   "source": {
-    "hash": "0x3fe08f20b0afefae9cb2cff3cf811c297958c7f72ab3d22431e10e0150433bbb",
+    "hash": "0x83e11fba7503b7c3c596a85e218525864b7d93d2902a59565f927570f783b5a3",
     "language": "ink! 5.1.1",
     "compiler": "rustc 1.92.0",
     "build_info": {
@@ -27,7 +27,8 @@
         "args": [],
         "default": false,
         "docs": [
-          "Initialize the contract with 6 horses and reward multipliers"
+          "Initialize the contract with 6 horses and reward multipliers",
+          "Default fee distribution: Dev 5%, Operator 5%, Pot 90%"
         ],
         "label": "new",
         "payable": false,
@@ -36,7 +37,7 @@
             "ink_primitives",
             "ConstructorResult"
           ],
-          "type": 23
+          "type": 24
         },
         "selector": "0x9bae9d5e"
       },
@@ -53,7 +54,7 @@
             "ink_primitives",
             "ConstructorResult"
           ],
-          "type": 23
+          "type": 24
         },
         "selector": "0xed4b9d1b"
       }
@@ -76,19 +77,19 @@
         "displayName": [
           "BlockNumber"
         ],
-        "type": 47
+        "type": 54
       },
       "chainExtension": {
         "displayName": [
           "ChainExtension"
         ],
-        "type": 49
+        "type": 56
       },
       "hash": {
         "displayName": [
           "Hash"
         ],
-        "type": 48
+        "type": 55
       },
       "maxEventTopics": 4,
       "staticBufferSize": 16384,
@@ -100,6 +101,58 @@
       }
     },
     "events": [
+      {
+        "args": [
+          {
+            "docs": [],
+            "indexed": false,
+            "label": "bet_amount",
+            "type": {
+              "displayName": [
+                "u128"
+              ],
+              "type": 9
+            }
+          },
+          {
+            "docs": [],
+            "indexed": false,
+            "label": "dev_share",
+            "type": {
+              "displayName": [
+                "u128"
+              ],
+              "type": 9
+            }
+          },
+          {
+            "docs": [],
+            "indexed": false,
+            "label": "operator_share",
+            "type": {
+              "displayName": [
+                "u128"
+              ],
+              "type": 9
+            }
+          },
+          {
+            "docs": [],
+            "indexed": false,
+            "label": "pot_share",
+            "type": {
+              "displayName": [
+                "u128"
+              ],
+              "type": 9
+            }
+          }
+        ],
+        "docs": [],
+        "label": "BetDistributed",
+        "module_path": "web3_horse_race::horse_race",
+        "signature_topic": "0x9353d5d5a0da3a31e11cfb93233d973044d96658b578776e8220d26d353436ed"
+      },
       {
         "args": [
           {
@@ -285,7 +338,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 47
+              "type": 54
             }
           }
         ],
@@ -352,7 +405,7 @@
         "ink",
         "LangError"
       ],
-      "type": 24
+      "type": 25
     },
     "messages": [
       {
@@ -389,7 +442,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 25
+          "type": 26
         },
         "selector": "0x2d10c9bd"
       },
@@ -417,7 +470,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 25
+          "type": 26
         },
         "selector": "0x410fcc9d"
       },
@@ -445,7 +498,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 28
+          "type": 29
         },
         "selector": "0xea817e65"
       },
@@ -502,7 +555,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 25
+          "type": 26
         },
         "selector": "0xb409d6e2"
       },
@@ -520,7 +573,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 29
+          "type": 30
         },
         "selector": "0xd1e38ef8"
       },
@@ -538,7 +591,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 28
+          "type": 29
         },
         "selector": "0x2106ac7a"
       },
@@ -566,7 +619,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 25
+          "type": 26
         },
         "selector": "0x552b606c"
       },
@@ -587,7 +640,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 30
+          "type": 31
         },
         "selector": "0x95dcf6c2"
       },
@@ -605,7 +658,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 32
+          "type": 33
         },
         "selector": "0xc88039b2"
       },
@@ -623,7 +676,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 34
+          "type": 35
         },
         "selector": "0x8a851ac1"
       },
@@ -661,7 +714,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 35
+          "type": 36
         },
         "selector": "0x28de2dda"
       },
@@ -679,7 +732,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 36
+          "type": 37
         },
         "selector": "0x6573b6c1"
       },
@@ -697,7 +750,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 39
+          "type": 40
         },
         "selector": "0x8ea058ce"
       },
@@ -725,7 +778,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 40
+          "type": 41
         },
         "selector": "0x4dca428a"
       },
@@ -743,7 +796,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 42
+          "type": 43
         },
         "selector": "0x07e3b8df"
       },
@@ -761,7 +814,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 35
+          "type": 36
         },
         "selector": "0x15ba28f5"
       },
@@ -779,7 +832,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 43
+          "type": 44
         },
         "selector": "0xf4fe3b80"
       },
@@ -797,7 +850,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 44
+          "type": 45
         },
         "selector": "0xb7f7c885"
       },
@@ -815,7 +868,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 45
+          "type": 46
         },
         "selector": "0xc51514c9"
       },
@@ -852,7 +905,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 35
+          "type": 36
         },
         "selector": "0x82a2fac2"
       },
@@ -880,7 +933,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 35
+          "type": 36
         },
         "selector": "0x95b82a9d"
       },
@@ -898,7 +951,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 46
+          "type": 47
         },
         "selector": "0x07fcd0b1"
       },
@@ -916,7 +969,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 25
+          "type": 26
         },
         "selector": "0x282573ab"
       },
@@ -944,9 +997,176 @@
             "ink",
             "MessageResult"
           ],
-          "type": 25
+          "type": 26
         },
         "selector": "0x367facd6"
+      },
+      {
+        "args": [
+          {
+            "label": "dev_address",
+            "type": {
+              "displayName": [
+                "AccountId"
+              ],
+              "type": 0
+            }
+          }
+        ],
+        "default": false,
+        "docs": [
+          " Set developer address (owner only)"
+        ],
+        "label": "set_dev_address",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 26
+        },
+        "selector": "0x6c6f137a"
+      },
+      {
+        "args": [
+          {
+            "label": "operator_address",
+            "type": {
+              "displayName": [
+                "AccountId"
+              ],
+              "type": 0
+            }
+          }
+        ],
+        "default": false,
+        "docs": [
+          " Set operator address (owner only)"
+        ],
+        "label": "set_operator_address",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 26
+        },
+        "selector": "0x04cce1a3"
+      },
+      {
+        "args": [
+          {
+            "label": "dev_fee_bps",
+            "type": {
+              "displayName": [
+                "u16"
+              ],
+              "type": 21
+            }
+          },
+          {
+            "label": "operator_fee_bps",
+            "type": {
+              "displayName": [
+                "u16"
+              ],
+              "type": 21
+            }
+          }
+        ],
+        "default": false,
+        "docs": [
+          " Set fee percentages (owner only)",
+          " dev_fee_bps and operator_fee_bps are in basis points (100 = 1%, 500 = 5%)",
+          " Total fees cannot exceed 10000 (100%)"
+        ],
+        "label": "set_fee_percentages",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 26
+        },
+        "selector": "0x067d0e29"
+      },
+      {
+        "args": [],
+        "default": false,
+        "docs": [
+          " Withdraw accumulated developer fees (dev only)"
+        ],
+        "label": "withdraw_dev_fees",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 48
+        },
+        "selector": "0x3fe15655"
+      },
+      {
+        "args": [],
+        "default": false,
+        "docs": [
+          " Withdraw accumulated operator fees (operator only)"
+        ],
+        "label": "withdraw_operator_fees",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 48
+        },
+        "selector": "0x187dba7f"
+      },
+      {
+        "args": [],
+        "default": false,
+        "docs": [
+          " Get fee distribution configuration"
+        ],
+        "label": "get_fee_config",
+        "mutates": false,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 50
+        },
+        "selector": "0x12136f86"
+      },
+      {
+        "args": [],
+        "default": false,
+        "docs": [
+          " Get accumulated fees"
+        ],
+        "label": "get_accumulated_fees",
+        "mutates": false,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 52
+        },
+        "selector": "0xbf3b5d4e"
       },
       {
         "args": [
@@ -972,7 +1192,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 30
+          "type": 31
         },
         "selector": "0xa74db34e"
       }
@@ -1206,13 +1426,67 @@
                 }
               },
               "name": "balances"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 0
+                }
+              },
+              "name": "dev_address"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 0
+                }
+              },
+              "name": "operator_address"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 21
+                }
+              },
+              "name": "dev_fee_bps"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 21
+                }
+              },
+              "name": "operator_fee_bps"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 9
+                }
+              },
+              "name": "dev_balance"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 9
+                }
+              },
+              "name": "operator_balance"
             }
           ],
           "name": "HorseRace"
         }
       },
       "root_key": "0x00000000",
-      "ty": 21
+      "ty": 22
     }
   },
   "types": [
@@ -1606,6 +1880,14 @@
       "id": 21,
       "type": {
         "def": {
+          "primitive": "u16"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "type": {
+        "def": {
           "composite": {
             "fields": [
               {
@@ -1620,7 +1902,7 @@
               },
               {
                 "name": "status",
-                "type": 22,
+                "type": 23,
                 "typeName": "<RaceStatus as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<3481146192u32, ()>,>>::Type"
               },
               {
@@ -1677,6 +1959,36 @@
                 "name": "balances",
                 "type": 16,
                 "typeName": "<Mapping<AccountId, u128> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<2761047943u32,\n()>,>>::Type"
+              },
+              {
+                "name": "dev_address",
+                "type": 0,
+                "typeName": "<AccountId as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<2163815683u32, ()>,>>::Type"
+              },
+              {
+                "name": "operator_address",
+                "type": 0,
+                "typeName": "<AccountId as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<3643878076u32, ()>,>>::Type"
+              },
+              {
+                "name": "dev_fee_bps",
+                "type": 21,
+                "typeName": "<u16 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<356130442u32, ()>,>>::Type"
+              },
+              {
+                "name": "operator_fee_bps",
+                "type": 21,
+                "typeName": "<u16 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<992564383u32, ()>,>>::Type"
+              },
+              {
+                "name": "dev_balance",
+                "type": 9,
+                "typeName": "<u128 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<3229949300u32, ()>,>>::Type"
+              },
+              {
+                "name": "operator_balance",
+                "type": 9,
+                "typeName": "<u128 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<1250347764u32, ()>,>>::Type"
               }
             ]
           }
@@ -1689,7 +2001,7 @@
       }
     },
     {
-      "id": 22,
+      "id": 23,
       "type": {
         "def": {
           "variant": {
@@ -1721,7 +2033,7 @@
       }
     },
     {
-      "id": 23,
+      "id": 24,
       "type": {
         "def": {
           "variant": {
@@ -1738,7 +2050,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -1754,7 +2066,7 @@
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -1763,7 +2075,7 @@
       }
     },
     {
-      "id": 24,
+      "id": 25,
       "type": {
         "def": {
           "variant": {
@@ -1782,7 +2094,7 @@
       }
     },
     {
-      "id": 25,
+      "id": 26,
       "type": {
         "def": {
           "variant": {
@@ -1790,7 +2102,7 @@
               {
                 "fields": [
                   {
-                    "type": 26
+                    "type": 27
                   }
                 ],
                 "index": 0,
@@ -1799,7 +2111,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -1811,11 +2123,11 @@
         "params": [
           {
             "name": "T",
-            "type": 26
+            "type": 27
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -1824,7 +2136,7 @@
       }
     },
     {
-      "id": 26,
+      "id": 27,
       "type": {
         "def": {
           "variant": {
@@ -1841,7 +2153,7 @@
               {
                 "fields": [
                   {
-                    "type": 27
+                    "type": 28
                   }
                 ],
                 "index": 1,
@@ -1857,7 +2169,7 @@
           },
           {
             "name": "E",
-            "type": 27
+            "type": 28
           }
         ],
         "path": [
@@ -1866,7 +2178,7 @@
       }
     },
     {
-      "id": 27,
+      "id": 28,
       "type": {
         "def": {
           "variant": {
@@ -1906,6 +2218,10 @@
               {
                 "index": 8,
                 "name": "InsufficientBalance"
+              },
+              {
+                "index": 9,
+                "name": "InvalidFeePercentage"
               }
             ]
           }
@@ -1918,7 +2234,7 @@
       }
     },
     {
-      "id": 28,
+      "id": 29,
       "type": {
         "def": {
           "variant": {
@@ -1935,7 +2251,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -1951,49 +2267,7 @@
           },
           {
             "name": "E",
-            "type": 24
-          }
-        ],
-        "path": [
-          "Result"
-        ]
-      }
-    },
-    {
-      "id": 29,
-      "type": {
-        "def": {
-          "variant": {
-            "variants": [
-              {
-                "fields": [
-                  {
-                    "type": 7
-                  }
-                ],
-                "index": 0,
-                "name": "Ok"
-              },
-              {
-                "fields": [
-                  {
-                    "type": 24
-                  }
-                ],
-                "index": 1,
-                "name": "Err"
-              }
-            ]
-          }
-        },
-        "params": [
-          {
-            "name": "T",
-            "type": 7
-          },
-          {
-            "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -2010,7 +2284,7 @@
               {
                 "fields": [
                   {
-                    "type": 31
+                    "type": 7
                   }
                 ],
                 "index": 0,
@@ -2019,7 +2293,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2031,11 +2305,11 @@
         "params": [
           {
             "name": "T",
-            "type": 31
+            "type": 7
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -2052,7 +2326,7 @@
               {
                 "fields": [
                   {
-                    "type": 11
+                    "type": 32
                   }
                 ],
                 "index": 0,
@@ -2061,7 +2335,7 @@
               {
                 "fields": [
                   {
-                    "type": 27
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2073,11 +2347,11 @@
         "params": [
           {
             "name": "T",
-            "type": 11
+            "type": 32
           },
           {
             "name": "E",
-            "type": 27
+            "type": 25
           }
         ],
         "path": [
@@ -2094,7 +2368,7 @@
               {
                 "fields": [
                   {
-                    "type": 33
+                    "type": 11
                   }
                 ],
                 "index": 0,
@@ -2103,7 +2377,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 28
                   }
                 ],
                 "index": 1,
@@ -2115,11 +2389,11 @@
         "params": [
           {
             "name": "T",
-            "type": 33
+            "type": 11
           },
           {
             "name": "E",
-            "type": 24
+            "type": 28
           }
         ],
         "path": [
@@ -2136,7 +2410,7 @@
               {
                 "fields": [
                   {
-                    "type": 14
+                    "type": 34
                   }
                 ],
                 "index": 0,
@@ -2145,7 +2419,7 @@
               {
                 "fields": [
                   {
-                    "type": 27
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2157,11 +2431,11 @@
         "params": [
           {
             "name": "T",
-            "type": 14
+            "type": 34
           },
           {
             "name": "E",
-            "type": 27
+            "type": 25
           }
         ],
         "path": [
@@ -2187,7 +2461,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 28
                   }
                 ],
                 "index": 1,
@@ -2203,7 +2477,7 @@
           },
           {
             "name": "E",
-            "type": 24
+            "type": 28
           }
         ],
         "path": [
@@ -2220,7 +2494,7 @@
               {
                 "fields": [
                   {
-                    "type": 3
+                    "type": 14
                   }
                 ],
                 "index": 0,
@@ -2229,7 +2503,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2241,11 +2515,11 @@
         "params": [
           {
             "name": "T",
-            "type": 3
+            "type": 14
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -2262,7 +2536,7 @@
               {
                 "fields": [
                   {
-                    "type": 37
+                    "type": 3
                   }
                 ],
                 "index": 0,
@@ -2271,7 +2545,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2283,11 +2557,11 @@
         "params": [
           {
             "name": "T",
-            "type": 37
+            "type": 3
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -2299,14 +2573,56 @@
       "id": 37,
       "type": {
         "def": {
-          "sequence": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 38
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 25
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
             "type": 38
+          },
+          {
+            "name": "E",
+            "type": 25
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 38,
+      "type": {
+        "def": {
+          "sequence": {
+            "type": 39
           }
         }
       }
     },
     {
-      "id": 38,
+      "id": 39,
       "type": {
         "def": {
           "composite": {
@@ -2342,7 +2658,7 @@
       }
     },
     {
-      "id": 39,
+      "id": 40,
       "type": {
         "def": {
           "variant": {
@@ -2359,7 +2675,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2375,7 +2691,7 @@
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -2384,7 +2700,7 @@
       }
     },
     {
-      "id": 40,
+      "id": 41,
       "type": {
         "def": {
           "variant": {
@@ -2392,7 +2708,7 @@
               {
                 "fields": [
                   {
-                    "type": 41
+                    "type": 42
                   }
                 ],
                 "index": 0,
@@ -2401,7 +2717,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2413,11 +2729,11 @@
         "params": [
           {
             "name": "T",
-            "type": 41
+            "type": 42
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -2426,7 +2742,7 @@
       }
     },
     {
-      "id": 41,
+      "id": 42,
       "type": {
         "def": {
           "variant": {
@@ -2459,48 +2775,6 @@
       }
     },
     {
-      "id": 42,
-      "type": {
-        "def": {
-          "variant": {
-            "variants": [
-              {
-                "fields": [
-                  {
-                    "type": 22
-                  }
-                ],
-                "index": 0,
-                "name": "Ok"
-              },
-              {
-                "fields": [
-                  {
-                    "type": 24
-                  }
-                ],
-                "index": 1,
-                "name": "Err"
-              }
-            ]
-          }
-        },
-        "params": [
-          {
-            "name": "T",
-            "type": 22
-          },
-          {
-            "name": "E",
-            "type": 24
-          }
-        ],
-        "path": [
-          "Result"
-        ]
-      }
-    },
-    {
       "id": 43,
       "type": {
         "def": {
@@ -2509,7 +2783,7 @@
               {
                 "fields": [
                   {
-                    "type": 11
+                    "type": 23
                   }
                 ],
                 "index": 0,
@@ -2518,7 +2792,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2530,11 +2804,11 @@
         "params": [
           {
             "name": "T",
-            "type": 11
+            "type": 23
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -2551,7 +2825,7 @@
               {
                 "fields": [
                   {
-                    "type": 10
+                    "type": 11
                   }
                 ],
                 "index": 0,
@@ -2560,7 +2834,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2572,11 +2846,11 @@
         "params": [
           {
             "name": "T",
-            "type": 10
+            "type": 11
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -2593,7 +2867,7 @@
               {
                 "fields": [
                   {
-                    "type": 13
+                    "type": 10
                   }
                 ],
                 "index": 0,
@@ -2602,7 +2876,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2614,11 +2888,11 @@
         "params": [
           {
             "name": "T",
-            "type": 13
+            "type": 10
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -2635,6 +2909,48 @@
               {
                 "fields": [
                   {
+                    "type": 13
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 25
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 13
+          },
+          {
+            "name": "E",
+            "type": 25
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 47,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
                     "type": 0
                   }
                 ],
@@ -2644,7 +2960,7 @@
               {
                 "fields": [
                   {
-                    "type": 24
+                    "type": 25
                   }
                 ],
                 "index": 1,
@@ -2660,7 +2976,7 @@
           },
           {
             "name": "E",
-            "type": 24
+            "type": 25
           }
         ],
         "path": [
@@ -2669,7 +2985,199 @@
       }
     },
     {
-      "id": 47,
+      "id": 48,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 49
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 25
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 49
+          },
+          {
+            "name": "E",
+            "type": 25
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 49,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 9
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 28
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 9
+          },
+          {
+            "name": "E",
+            "type": 28
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 50,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 51
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 25
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 51
+          },
+          {
+            "name": "E",
+            "type": 25
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 51,
+      "type": {
+        "def": {
+          "tuple": [
+            0,
+            0,
+            21,
+            21
+          ]
+        }
+      }
+    },
+    {
+      "id": 52,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 53
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 25
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 53
+          },
+          {
+            "name": "E",
+            "type": 25
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 53,
+      "type": {
+        "def": {
+          "tuple": [
+            9,
+            9
+          ]
+        }
+      }
+    },
+    {
+      "id": 54,
       "type": {
         "def": {
           "primitive": "u32"
@@ -2677,7 +3185,7 @@
       }
     },
     {
-      "id": 48,
+      "id": 55,
       "type": {
         "def": {
           "composite": {
@@ -2697,7 +3205,7 @@
       }
     },
     {
-      "id": 49,
+      "id": 56,
       "type": {
         "def": {
           "variant": {}


### PR DESCRIPTION
- Add dev_address and operator_address storage fields
- Add dev_fee_bps and operator_fee_bps (default 5% each, 90% to pot)
- Add dev_balance and operator_balance for accumulated fees
- Distribute bet amount on place_exacta_bet: Dev, Operator, Pot
- Add set_dev_address, set_operator_address, set_fee_percentages functions
- Add withdraw_dev_fees, withdraw_operator_fees functions
- Add get_fee_config, get_accumulated_fees query functions
- Add BetDistributed event
- Add InvalidFeePercentage error type

Closes #3